### PR TITLE
Miscellaneous fixes

### DIFF
--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -24,5 +24,8 @@ all: $(EE_BIN)
 	ee-strip -s -d -R .mdebug.eabi64 -R .reginfo -R .comment $(EE_BIN)
 	rm -f *.o *.s
 
+clean:
+	rm -f *.o *.s *.elf
+
 include $(PS2SDK)/samples/Makefile.pref
 include $(PS2SDK)/samples/Makefile.eeglobal

--- a/engine/engine_asm.S
+++ b/engine/engine_asm.S
@@ -697,15 +697,16 @@ HookSetupThread:
 	 */
 	lw	$t1, numhooks
 	nop
-	bgtz	$t1, 1f
+	bgtz	$t1, 4f
 	nop
 	
 	/* find a place to hook */
 	jal	AutoHooker
 	nop
+4:
+	la	$t3, hooklist
 1:
 	/* hook only if opcodes are equal */
-	la	$t3, hooklist
 	lw	$v0, 0($t3)
 	beqz	$v0, 2f
 	lw	$v1, 4($t3)

--- a/src/saveformats/zip.c
+++ b/src/saveformats/zip.c
@@ -20,6 +20,7 @@ int extractZIP(gameSave_t *save, device_t dst)
     char dstName[100];
     u8 *data;
     float progress = 0.0;
+    char *ptr;
     
     if(!save || !(dst & (MC_SLOT_1|MC_SLOT_2)))
         return 0;
@@ -43,7 +44,9 @@ int extractZIP(gameSave_t *save, device_t dst)
 
     strcpy(dirNameTemp, fileName);
 
-    dirNameTemp[(unsigned int)(strstr(dirNameTemp, "/") - dirNameTemp)] = 0;
+    ptr = strstr(dirNameTemp, "/");
+    if (ptr)
+        dirNameTemp[(unsigned int)(ptr - dirNameTemp)] = 0;
 
     printf("Directory name: %s\n", dirNameTemp);
 
@@ -76,7 +79,8 @@ int extractZIP(gameSave_t *save, device_t dst)
         unzReadCurrentFile(zf, data, fileInfo.uncompressed_size);
         unzCloseCurrentFile(zf);
         
-        snprintf(dstName, 100, "%s/%s", dirName, strstr(fileName, "/") + 1);
+        ptr = strstr(fileName, "/");
+        snprintf(dstName, 100, "%s/%s", dirName, (ptr) ? ptr + 1 : fileName);
 
         printf("Writing %s...", dstName);
 

--- a/src/textcheats.c
+++ b/src/textcheats.c
@@ -579,8 +579,7 @@ static inline int getToken(const unsigned char *line, const int len)
 
     if(UNLIKELY(len > 3 &&
        ((g_ctx.lastToken == TOKEN_MAP_START) || 
-        (g_ctx.lastToken == TOKEN_MAP_ENTRY) ||
-        (g_ctx.lastToken == 0))))
+        (g_ctx.lastToken == TOKEN_MAP_ENTRY))))
     {
         c = line;
         while(isxdigit(*c))
@@ -605,8 +604,6 @@ static inline int getToken(const unsigned char *line, const int len)
 
         if(numTokens == 17)
             return TOKEN_CODE;
-        else
-            return TOKEN_CHEAT;
     }
 
     if((line[0] == '/' && line[1] == '/') || line[0] == '#')


### PR DESCRIPTION
- `bootstrap/Makefile`: Add missing `clean` target.
- `engine/engine_asm.S`: Fix multiple hook (enable code) support.
- `src/saveformats/zip.c`: Fix handling of ZIP files with no directory entries.
- `src/textcheats.c`: Fix false positives at `getToken` function.